### PR TITLE
Remove template closing tag in template interpolation

### DIFF
--- a/dlt_openapi/renderer/default/templates/README.md.j2
+++ b/dlt_openapi/renderer/default/templates/README.md.j2
@@ -11,4 +11,4 @@ Created with [dlt-openapi](https://github.com/dlt-hub/dlt-openapi) v. {{version}
 * {{ endpoint.detected_resource_name }}  
   _{{endpoint.method}} {{ endpoint.path }}_  
   {% if endpoint.description %}{{endpoint.description}}{% endif %}
-{% endfor %}%}
+{% endfor %}


### PR DESCRIPTION
Current template renders additional `%}` at the end of readme 
<img width="544" alt="image" src="https://github.com/dlt-hub/dlt-openapi/assets/354868/98e5aa0d-9bc3-49ea-a6a6-5d4f9bc4878a">
