### PR TITLE
docs: fix running instructions

### DIFF
--- a/dlt_init_openapi/__init__.py
+++ b/dlt_init_openapi/__init__.py
@@ -63,7 +63,7 @@ class Project:  # pylint: disable=too-many-instance-attributes
                 logger.warning("You have not selected any endpoints, all endpoints will be rendered.")
         self.renderer.run(self.openapi, dry=dry)
         logger.success(f"Rendered project to: {self.config.project_dir}")
-        logger.info("You can now run your pipeline from this folder with 'python pipeline.py'.")
+        logger.info("You can now run your pipeline from this folder with 'python {self.config.project_dir}.py'.")
 
     def print_warnings(self) -> None:
         """print warnings to logger if any where encountered for endpoints that are being rendered"""


### PR DESCRIPTION
For a generation like this:
```sh
dlt-init-openapi affinity --url https://raw.githubusercontent.com/planet-a-ventures/affinity-node/refs/heads/main/openapi/2024-11-18.json --global-limit 2
```

the following scaffold is generated:
```
.
├── README.md
├── affinity
│   └── __init__.py
├── affinity_pipeline.py
├── requirements.txt
└── rest_api
    ├── README.md
    ├── __init__.py
    ├── config_setup.py
    ├── exceptions.py
    ├── requirements.txt
    ├── typing.py
    └── utils.py
```
inside `./affinity_pipeline/`

which means that:
```sh
cd affinity_pipeline
python pipeline.py
```
yields:
```
/Users/joscha/dev/dlt-test/.devenv/state/venv/bin/python: can't open file '/Users/joscha/dev/dlt-test/affinity_pipeline/pipeline.py': [Errno 2] No such file or directory
```
