### PR TITLE
fix: Update `rest_api` source location

### DIFF
--- a/dlt_init_openapi/utils/update_rest_api.py
+++ b/dlt_init_openapi/utils/update_rest_api.py
@@ -5,8 +5,8 @@ from loguru import logger
 
 from dlt_init_openapi.config import REST_API_SOURCE_LOCATION
 
-BASEPATH = "https://raw.githubusercontent.com/dlt-hub/verified-sources/master/sources/rest_api/"
-FILES = ["README.md", "__init__.py", "config_setup.py", "exceptions.py", "requirements.txt", "typing.py", "utils.py"]
+BASEPATH = "https://raw.githubusercontent.com/dlt-hub/dlt/refs/heads/devel/dlt/sources/rest_api/"
+FILES = [ "__init__.py", "config_setup.py", "exceptions.py",  "typing.py", "utils.py"]
 
 
 def update_rest_api(force: bool = False) -> None:


### PR DESCRIPTION
Hi community,

I'm opening that PR to fix an issue I met trying to use the generator (see Slack [thread](https://dlthub-community.slack.com/archives/C04DQA7JJN6/p1753963305544129)):

<img width="2929" height="1533" alt="Screenshot 2025-07-31 at 2 01 20 PM" src="https://github.com/user-attachments/assets/bcf9d052-ae85-4eee-8a61-31dc4e96ae48" />

---

The issue happens because the `rest_api` source has been moved to the `dlt` [repo](https://github.com/dlt-hub/dlt) from the `verified-source` [repo](https://github.com/dlt-hub/verified-sources) in that [commit ](https://github.com/dlt-hub/verified-sources/commit/e332188671328c1eee2c56c7dcb1fdf3e7149965#diff-680519ffafcca536e23fc072a11d7a4c7ff796c93c884a0e5062610c484daa8d)but the generator hasn't been updated.

Nicolas 