### PR TITLE
Fix config loading without source name

### DIFF
--- a/dlt_init_openapi/cli/__init__.py
+++ b/dlt_init_openapi/cli/__init__.py
@@ -23,6 +23,7 @@ def _print_version(value: bool) -> None:
 
 
 def _load_config(path: Optional[pathlib.Path], config: Any) -> Config:
+    config = {key: value for key, value in config.items() if value is not None}
     if not path:
         c = Config(**config)
     else:
@@ -31,6 +32,11 @@ def _load_config(path: Optional[pathlib.Path], config: Any) -> Config:
         except Exception as err:
             raise typer.BadParameter("Unable to parse config") from err
     return c
+
+
+def _ensure_project_dir(config: Config) -> None:
+    if config.project_dir is None:
+        raise typer.BadParameter("Provide a source name or set project_name in the config file")
 
 
 # pylint: disable=too-many-arguments
@@ -111,6 +117,8 @@ def _init_command_wrapped(
                 "allow_openapi_2": allow_openapi_2,
             },
         )
+
+        _ensure_project_dir(config)
 
         if config.project_dir.exists():
             if not interactive:

--- a/dlt_init_openapi/config.py
+++ b/dlt_init_openapi/config.py
@@ -82,5 +82,6 @@ class Config(BaseModel):
             config_data = json.loads(path.read_text())
         else:
             config_data = yaml.safe_load(path.read_text())
-        config = Config(**config_data, **kwargs)
+        config_data = config_data or {}
+        config = Config(**{**config_data, **kwargs})
         return config

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -40,3 +40,58 @@ def test_load_from_path(tmp_path: Path, filename, dump, relative):
     config = Config.load_from_path(yml_file)
     assert config.project_name == "project_name"
     assert config.package_name == "package_name"
+
+
+def test_load_from_path_allows_kwargs_to_override_file_values(tmp_path: Path):
+    yml_file = tmp_path.joinpath("example.yml")
+    yml_file.write_text(
+        yaml.dump(
+            {
+                "project_name": "config-project",
+                "package_name": "config_package",
+            }
+        )
+    )
+
+    config = Config.load_from_path(yml_file, project_name="cli-project")
+
+    assert config.project_name == "cli_project"
+    assert config.package_name == "config_package"
+
+
+def test_load_config_keeps_file_project_name_when_source_is_missing(tmp_path: Path):
+    from dlt_init_openapi.cli import _load_config
+
+    yml_file = tmp_path.joinpath("config.yml")
+    yml_file.write_text(
+        yaml.dump(
+            {
+                "project_name": "posthog",
+                "project_folder_suffix": "test",
+            }
+        )
+    )
+
+    config = _load_config(
+        path=yml_file,
+        config={
+            "project_name": None,
+            "package_name": None,
+            "spec_url": "https://example.com/openapi.yaml",
+            "spec_path": None,
+            "global_limit": 0,
+        },
+    )
+
+    assert config.project_name == "posthog"
+    assert config.spec_url == "https://example.com/openapi.yaml"
+    assert config.project_dir.name == "posthogtest"
+
+
+def test_ensure_project_dir_rejects_missing_project_name():
+    import typer
+
+    from dlt_init_openapi.cli import _ensure_project_dir
+
+    with pytest.raises(typer.BadParameter, match="Provide a source name"):
+        _ensure_project_dir(Config(spec_url="https://example.com/openapi.yaml"))


### PR DESCRIPTION
## Summary
- ignore unset CLI options when loading a config file so values like `project_name` from the file are preserved
- merge config file values with provided CLI values explicitly, with provided CLI values taking precedence
- report a clear Typer validation error when neither a source name nor `project_name` is available

Fixes #126
Fixes #137

## Validation
- `git diff --check`
- inspected the changed config loading and CLI project directory guard
- Not run locally