### PR TITLE
Use rest_api_resources in generated sources

### DIFF
--- a/dlt_init_openapi/renderer/default/templates/source.py.j2
+++ b/dlt_init_openapi/renderer/default/templates/source.py.j2
@@ -1,10 +1,9 @@
-from typing import List
+from typing import Iterable
 
 import dlt
 from dlt.extract.source import DltResource
 
-from dlt.sources.rest_api.typing import RESTAPIConfig
-from dlt.sources.rest_api import rest_api_source
+from dlt.sources.rest_api import RESTAPIConfig, rest_api_resources
 
 
 @dlt.source(name="{{source_name}}", max_table_nesting=2)
@@ -15,7 +14,7 @@ def {{ source_name }}(
         {% endfor %}
         {% endif %}
         base_url: str = dlt.config.value,
-) -> List[DltResource]:
+) -> Iterable[DltResource]:
 
     # source configuration
     source_config: RESTAPIConfig = {
@@ -107,5 +106,4 @@ def {{ source_name }}(
         ]
     }
 
-    return rest_api_source(source_config)
-
+    yield from rest_api_resources(source_config)

--- a/tests/integration/basics/test_misc.py
+++ b/tests/integration/basics/test_misc.py
@@ -1,5 +1,6 @@
 from dlt_init_openapi.config import Config
-from tests.integration.utils import get_indexed_resources
+from tests.cases import case_path
+from tests.integration.utils import get_detected_project_from_open_api, get_indexed_resources
 
 
 def test_endpoint_selection() -> None:
@@ -19,3 +20,16 @@ def test_endpoint_selection() -> None:
     )
     assert len(filtered_resources.keys()) == 2
     assert list(filtered_resources.keys()) == [base_keys[0], base_keys[3]]
+
+
+def test_source_template_yields_rest_api_resources() -> None:
+    project = get_detected_project_from_open_api(
+        case_path("artificial", "pagination.yml"),
+        config=Config(name_resources_by_operation=True),
+    )
+    project.render(dry=True)
+    source = project.renderer._render_source()  # type: ignore
+
+    assert "from dlt.sources.rest_api import RESTAPIConfig, rest_api_resources" in source
+    assert "yield from rest_api_resources(source_config)" in source
+    assert "rest_api_source(" not in source

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -55,7 +55,7 @@ Oauth20Credentials = Any
 
     if rt == "dict":
         source = source.replace('@dlt.source(name="test_source", max_table_nesting=2)', "")
-        source = source.replace("rest_api_source(source_config)", "source_config")
+        source = source.replace("yield from rest_api_resources(source_config)", "return source_config")
         source = source.replace("dlt.secrets.value", '"SECRET_VALUE"')
 
     # The template now correctly uses dlt.sources.rest_api imports


### PR DESCRIPTION
## Summary
- update generated source imports to use `RESTAPIConfig` and `rest_api_resources` from `dlt.sources.rest_api`
- have generated `@dlt.source` functions yield resources via `rest_api_resources(source_config)` instead of returning a nested `rest_api_source(...)`
- adjust the rendered-source helper and add coverage for the generated import/yield shape

Fixes #133.

## Validation
- `git diff --check -- dlt_init_openapi/renderer/default/templates/source.py.j2 tests/integration/utils.py tests/integration/basics/test_misc.py`
- inspected the generated source template against the current dlt REST API source templates
- Not run locally